### PR TITLE
fix(adminwebbackend): 8192 バイト境界にマルチバイト文字がまたがる UTF-8 CSV で CSV 分析が誤検知により失敗するのを修正

### DIFF
--- a/lambda/adminwebbackend/app.py
+++ b/lambda/adminwebbackend/app.py
@@ -1,3 +1,4 @@
+import codecs
 import csv
 import io
 import json
@@ -236,8 +237,11 @@ def _detect_encoding(bucket: str, key: str) -> None:
     """S3 の CSV ファイル先頭を読み取って UTF-8 であることを検証。UTF-8 以外はエラー。"""
     resp = s3.get_object(Bucket=bucket, Key=key, Range="bytes=0-8192")
     raw = resp["Body"].read()
+    # Range GET の末尾がマルチバイト文字の途中で切れる可能性があるため、
+    # incremental decoder を使って「末尾の不完全バイト列」を許容する。
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
     try:
-        raw.decode("utf-8")
+        decoder.decode(raw, final=False)
     except UnicodeDecodeError:
         raise ValueError(f"UTF-8 以外のエンコーディングが検出されました: {key}。CSV は UTF-8 で保存してください。")
 


### PR DESCRIPTION
## 概要
admin 画面の CSV 分析機能で、正しい UTF-8 の CSV ファイルにもかかわらず「UTF-8 以外のエンコーディングが検出されました」というエラーで失敗するケースがあったので修正します。

## 再現する条件
日本語などのマルチバイト文字を含む UTF-8 CSV で、ちょうどファイル先頭 8192 バイト目がマルチバイト文字の途中に当たる場合に発生します（例: [データサイエンス 100 本ノック](https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess) の `category.csv`）。

admin 画面で表示されるエラー:

```
CSV分析エラー: UTF-8 以外のエンコーディングが検出されました: <key>.csv。CSV は UTF-8 で保存してください。
```

## 原因
`lambda/adminwebbackend/app.py` の `_detect_encoding` は、S3 の Range GET でファイル先頭 8193 バイトだけを取得し、それを `raw.decode("utf-8")` で strict モードでデコードしてエンコーディングを判定しています。

```python
resp = s3.get_object(Bucket=bucket, Key=key, Range="bytes=0-8192")
raw = resp["Body"].read()
raw.decode("utf-8")
```

オフセット 8192 バイト目がマルチバイト UTF-8 シーケンスの途中（日本語は 1 文字 3 バイト）に当たる場合、続きのバイトが取得範囲外のため以下の例外になります。

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe6 in position 8192: unexpected end of data
```

ファイル自体は正しい UTF-8 ですが、Range 境界の切り方の副作用で本来の意図であるエンコーディング判定が壊れていました。日本語を含む CSV では踏みやすい条件です。

## 修正内容
`codecs.getincrementaldecoder` を使って `final=False` でデコードすることで、Range 境界でマルチバイト列が途中で切れているケースを許容します。本当に UTF-8 でないファイル（Shift_JIS、CP932 など）は従来通り `UnicodeDecodeError` で失敗するため、検知の意図は維持されます。

```python
decoder = codecs.getincrementaldecoder("utf-8")(errors="strict")
try:
    decoder.decode(raw, final=False)
except UnicodeDecodeError:
    raise ValueError(f"UTF-8 以外のエンコーディングが検出されました: {key}。CSV は UTF-8 で保存してください。")
```

## 動作確認
`stackPrefix=utf8test` で実 AWS 環境にデプロイし、以下を確認しました。

- 修正前: 100 本ノックの `category.csv`（UTF-8、BOM 付き、日本語多数）で admin 画面から分析 → 「UTF-8 以外のエンコーディングが検出されました」で失敗（再現）。
- 修正後（Lambda のみ再デプロイ）: 同じファイルで分析が正常終了。
- 修正後: `testdata/` 配下の既存 CSV も従来通り分析成功。
- ローカルで Shift_JIS にエンコードしたバイト列を渡すテスト: 従来通り `UnicodeDecodeError: invalid start byte` で失敗することを確認（非 UTF-8 検知の機能は維持）。

## 対象ファイル
- `lambda/adminwebbackend/app.py` のみ（5 行追加 / 1 行削除）
